### PR TITLE
Replace image URLs numbers.

### DIFF
--- a/src/contract-logic/index.ts
+++ b/src/contract-logic/index.ts
@@ -31,7 +31,7 @@ import { claimFunds } from "./transactions/claimFunds"
   // };
   // let startAuctionTransaction = await startAuction(newAuction);
   // await sendTransaction(startAuctionTransaction, auctionOwner);
-  const auction_id = "hello-auction"
+  const auction_id = "asd"
 
   var auction = await getAuction(CONNECTION, auction_id)
   let auctionOwnerPubkey = new PublicKey(auction.ownerPubkey)

--- a/src/contract-logic/queries/getAuctions.ts
+++ b/src/contract-logic/queries/getAuctions.ts
@@ -97,27 +97,27 @@ export async function getAuction(connection: Connection, id: string): Promise<Au
 
   const currentChildEdition = masterEditionDeserialized.supply.toNumber()
   const auctionOwnerPubkey = new PublicKey(auctionRootStateDeserialized.auctionOwner)
-  // TODO read only master metadata -> get url
-  // TODO append edition number to url to get the specific images
-  var metadata
-  if (currentChildEdition == 0) {
-    metadata = await getMasterMetadata(connection, auctionOwnerPubkey, auctionId)
-  } else {
-    // we have minted a child nft so return with master's data
-    metadata = await getChildMetadata(auctionOwnerPubkey, auctionId, currentChildEdition)
-  }
+  const masterMetadata = await getMasterMetadata(connection, auctionOwnerPubkey, auctionId)
+  const currentCycle = auctionRootStateDeserialized.status.currentAuctionCycle.toNumber()
+  let uri = masterMetadata.uri
+
+  // TODO use regex? this is not very flexible
+  let uri_split = uri.split(".")
+  uri_split[uri_split.length - 2] = currentCycle.toString()
+  uri = uri_split.join(".")
+
   return {
     id: id,
     name: parseAuctionId(auctionRootStateDeserialized.auctionName),
     ownerPubkey: auctionOwnerPubkey,
     nftData: {
-      name: metadata.name,
-      symbol: metadata.symbol,
-      uri: metadata.uri,
+      name: masterMetadata.name,
+      symbol: masterMetadata.symbol,
+      uri,
     },
     bids: auctionCycleStateDeserialized.bidHistory,
     cyclePeriod: auctionRootStateDeserialized.config.cyclePeriod.toNumber(),
-    currentCycle: +auctionRootStateDeserialized.status.currentAuctionCycle.toNumber() + 1, //+currentChildEdition + 1, // ?
+    currentCycle: +currentCycle, // + 1 //+currentChildEdition + 1, // ?
     numberOfCycles: auctionRootStateDeserialized.config.numberOfCycles.toNumber(),
     minBid: auctionRootStateDeserialized.config.minimumBidAmount.toNumber(),
     startTimestamp: auctionCycleStateDeserialized.startTime.toNumber(),

--- a/src/contract-logic/queries/getAuctions.ts
+++ b/src/contract-logic/queries/getAuctions.ts
@@ -101,10 +101,8 @@ export async function getAuction(connection: Connection, id: string): Promise<Au
   const currentCycle = auctionRootStateDeserialized.status.currentAuctionCycle.toNumber()
   let uri = masterMetadata.uri
 
-  // TODO use regex? this is not very flexible
-  let uri_split = uri.split(".")
-  uri_split[uri_split.length - 2] = currentCycle.toString()
-  uri = uri_split.join(".")
+  const regex = /([^\/]+\/*\/)([^/]*)(\.(jpeg|png|svg|gif|jpg))/
+  uri = uri.replace(regex, "$1" + currentCycle + "$3")
 
   return {
     id: id,


### PR DESCRIPTION
Aims to resolve #1 by the following steps:
- when reading auction data, we only read the master edition NFT's image url, which is assumed to be `something/0.extension`
- we also read the current auction cycle
- the uploaded image url is changed such that the `0` is replaced by the current auction cycle to get `something/<current-auction-cycle>.extension`

This solution is quite inflexible though, and might be replaced by a some kind of regex search and replace logic.